### PR TITLE
Reduce object allocations when using parents

### DIFF
--- a/lib/thread_parent.rb
+++ b/lib/thread_parent.rb
@@ -33,10 +33,10 @@ class Thread
   end
 
   def parents
-    ThreadParent::Parents.new(self)
+    @parents ||= ThreadParent::Parents.new(self)
   end
 
   def self.parents
-    ThreadParent::Parents.new(Thread.current)
+    Thread.current.parents
   end
 end

--- a/test/test_thread_parent.rb
+++ b/test/test_thread_parent.rb
@@ -29,6 +29,14 @@ class TestThreadParent < MiniTest::Unit::TestCase
     }.join
   end
 
+  def test_can_find_thread_variable_in_parents_parent_using_class_method
+    Thread.new {
+      Thread.new {
+        assert_equal 'a', Thread.parents[:a]
+      }.join
+    }.join
+  end
+
   def test_can_override_parents_thread_variable
     thread = Thread.new {
       Thread.current[:a] = 'b'


### PR DESCRIPTION
I noticed that every time you call parents, it creates a new Parents instance creating unnecessary object allocations.  This PR lazily loads and stores the Parents object.
